### PR TITLE
fix(macros): addresses incomplete AST generation

### DIFF
--- a/packages/superjucks/src/nodes/Macro.ts
+++ b/packages/superjucks/src/nodes/Macro.ts
@@ -12,7 +12,7 @@ export default class MacroNode extends Node {
 
     const name = parser.parsePrimary(true);
     const args = parser.parseSignature();
-    const node = new MacroNode(macroTok.line, macroTok.col, { name, args });
+    const node = new MacroNode(macroTok.line, macroTok.col, { name, args, body: null });
 
     parser.advanceAfterBlockEnd(macroTok.value);
     node.body = parser.parseUntilBlocks('endmacro');

--- a/packages/superjucks/src/tests/Parser.ts
+++ b/packages/superjucks/src/tests/Parser.ts
@@ -265,21 +265,6 @@ test('should parse is operator', t => {
   ]);
 });
 
-test('should parse default function parameters', t => {
-  t.deepEqual(p('{% macro foo(bar, baz = 2) %}{% endmacro %}'), [
-    Nodes.Root,
-    [
-      Nodes.Macro,
-      [Nodes.Symbol, 'foo'],
-      [
-        Nodes.List,
-        [Nodes.Symbol, 'bar'],
-        [Nodes.Assign, [Nodes.Symbol, 'baz'], [Nodes.Literal, 2]]
-      ]
-    ]
-  ]);
-});
-
 test('should throw on unterminated comments', t => {
   t.throws(() => p('{# foo'));
 });

--- a/packages/superjucks/src/tests/configs/Jinja.ts
+++ b/packages/superjucks/src/tests/configs/Jinja.ts
@@ -120,11 +120,29 @@ test('should cast == and != to strict operators', t => {
 test('should allow kwargs to be called inside macro', t => {
   t.deepEqual(
     p(
-      '{% macro render_div() %}{{ kwargs["baz"] }}{% endmacro %}{{ render_div(baz=2) }}'
+      '{% macro render_div(foo = "bar") %}{{ foo }}{{ kwargs["baz"] }}{% endmacro %}{{ render_div(baz=2) }}'
     ),
     [
       Nodes.Root,
-      [Nodes.Macro, [Nodes.Symbol, 'render_div'], [Nodes.List]],
+      [
+        Nodes.Macro,
+        [Nodes.Symbol, 'render_div'],
+        [
+          Nodes.List,
+          [
+            KeywordArgs,
+            [Nodes.Pair, [Nodes.Symbol, 'foo'], [Nodes.Literal, 'bar']]
+          ]
+        ],
+        [
+          Nodes.List,
+          [Nodes.Output, [Nodes.Symbol, 'foo']],
+          [
+            Nodes.Output,
+            [Nodes.LookupVal, [Nodes.Symbol, 'kwargs'], [Nodes.Literal, 'baz']]
+          ]
+        ]
+      ],
       [
         Nodes.Output,
         [

--- a/packages/superjucks/src/tests/nodes/macro.ts
+++ b/packages/superjucks/src/tests/nodes/macro.ts
@@ -1,0 +1,19 @@
+import test from 'ava';
+import * as Nodes from '../../nodes/index';
+import { ast as p } from '../Parser';
+
+test('should parse default function parameters', t => {
+  t.deepEqual(p('{% macro foo(bar, baz = 2) %}{{ bar }}{% endmacro %}'), [
+    Nodes.Root,
+    [
+      Nodes.Macro,
+      [Nodes.Symbol, 'foo'],
+      [
+        Nodes.List,
+        [Nodes.Symbol, 'bar'],
+        [Nodes.Assign, [Nodes.Symbol, 'baz'], [Nodes.Literal, 2]]
+      ],
+      [Nodes.List, [Nodes.Output, [Nodes.Symbol, 'bar']]]
+    ]
+  ]);
+});


### PR DESCRIPTION
Previously, `macro` node iterators did not include the body field. Added null body initializer to the macro constructor. This led to some tests ASTs being rendered incorrectly.