### PR TITLE
feat(lexer): updates lexer to better structure code, accept non-prefixed regexes

### DIFF
--- a/packages/superjucks/src/tests/Parser.ts
+++ b/packages/superjucks/src/tests/Parser.ts
@@ -34,7 +34,7 @@ test('should parse literal types', t => {
     Nodes.Root,
     [Nodes.Output, [Nodes.Symbol, 'foo']]
   ]);
-  t.deepEqual(p('{{ r/23/gi }}'), [
+  t.deepEqual(p('{{ /23/gi }}'), [
     Nodes.Root,
     [Nodes.Output, [Nodes.Literal, /23/gi]]
   ]);


### PR DESCRIPTION
This is obviously a compat break from Nunjucks, but is a QOL change and fits more with the JS idioms of Superjucks.

```jinja
{# nunjucks #}
{% set regexp = r/12345/g %}

{# superjucks #}
{% set regexp = /12345/g %}
```

I've updated the lexer so the regex detector can be easily overriden (for the Nunjucks config).