### PR TITLE
feat(nodes): adds additional nodes.

### DIFF
--- a/packages/superjucks-runtime/package.json
+++ b/packages/superjucks-runtime/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "watch": "tsc -w",
     "lint": "tslint --project ../../tsconfig.json"
   }
 }

--- a/packages/superjucks-runtime/src/Buffer.ts
+++ b/packages/superjucks-runtime/src/Buffer.ts
@@ -3,12 +3,14 @@ import * as escape from 'escape-html';
 export default class Buffer {
   private _buf: string[] = [];
   public esc(val: any) {
-    this._buf.push(escape(val));
+    const v = escape(val);
+    this._buf.push(v === undefined ? '' : v);
   }
   public write(val: any) {
-    this._buf.push(val);
+    const v = val;
+    this._buf.push(v === undefined ? '' : v);
   }
   public out() {
-    return this._buf.join('\n');
+    return this._buf.join('');
   }
 }

--- a/packages/superjucks-runtime/src/runtime.ts
+++ b/packages/superjucks-runtime/src/runtime.ts
@@ -81,6 +81,7 @@ export function iterasync(i, forEach, ifElse) {
     resolve();
   });
 }
+
 export function itersync(iterable: Iterable<any>, forEach, ifElse) {
   const promises = [];
   return new Promise(async (resolve, reject) => {

--- a/packages/superjucks-runtime/src/tests/runtime.ts
+++ b/packages/superjucks-runtime/src/tests/runtime.ts
@@ -61,7 +61,7 @@ test('sync should iterate through a synchronous iterator', async t => {
 });
 
 test('async should iterate through an asynchronous iterator', async t => {
-  const z = async function* (item) {
+  const z = async function*(item) {
     for (const i of item) {
       yield i;
     }

--- a/packages/superjucks-runtime/src/tests/runtime.ts
+++ b/packages/superjucks-runtime/src/tests/runtime.ts
@@ -1,5 +1,8 @@
 import test from 'ava';
-import { brandSafeString, contains, copySafeness, entries, range } from '../runtime';
+import { brandSafeString, contains, copySafeness, entries, iterasync, itersync, range } from '../runtime';
+
+(Symbol as any).asyncIterator = (Symbol as any).asyncIterator
+  || Symbol.for('Symbol.asyncIterator');
 
 test('entries should split non-iterables into iterables', t => {
   const hash = { one: 1, two: 2 };
@@ -37,4 +40,48 @@ test('range should generate an array of numbers', async t => {
   t.deepEqual(r1, [ -4, -2, 0, 2, 4 ]);
   t.deepEqual(r2, [ -3, -1, 1 ]);
   t.deepEqual(r3, [ -3, -2, -1, 0, 1, 2 ]);
+});
+
+test('sync should iterate through a synchronous iterator', async t => {
+  const a = [];
+  const b = [];
+  const x = [ 1, 2, 3, 4, 5 ];
+  const y = '';
+
+  itersync(x, item => {
+    a.push(item);
+  }, () => a.push('☹️'));
+
+  itersync(y, item => {
+    b.push(item);
+  }, () => b.push('☹️'));
+
+  t.deepEqual(a, x);
+  t.deepEqual(b, [ '☹️' ]);
+});
+
+test('async should iterate through an asynchronous iterator', async t => {
+  const z = async function* (item) {
+    for (const i of item) {
+      yield i;
+    }
+  };
+
+  const a = [];
+  const b = [];
+  const x = [ 1, 2, 3, 4, 5 ];
+  const y = '';
+
+  await iterasync(z(x), item => {
+    a.push(item);
+  }, () => a.push('☹️'));
+
+  await iterasync(z(y), item => {
+    b.push(item);
+  }, () => b.push('☹️'));
+
+  console.info(a, b);
+
+  t.deepEqual(a, [ 1, 2, 3, 4, 5 ]);
+  t.deepEqual(b, [ '☹️' ]);
 });

--- a/packages/superjucks-runtime/tsconfig.json
+++ b/packages/superjucks-runtime/tsconfig.json
@@ -1,9 +1,14 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es6",
     "module": "commonjs",
     "rootDir": "src",
     "outDir": "lib",
-    "inlineSourceMap": true
+    "inlineSourceMap": true,
+    "lib": [
+      "es2015",
+      "es2017",
+      "esnext.asynciterable"
+    ]
   }
 }

--- a/packages/superjucks/package.json
+++ b/packages/superjucks/package.json
@@ -9,6 +9,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc",
+    "watch": "tsc -w",
     "lint": "tslint --project ../../tsconfig.json"
   }
 }

--- a/packages/superjucks/src/Frame.ts
+++ b/packages/superjucks/src/Frame.ts
@@ -8,7 +8,6 @@ export default class Frame {
   public set(name: string, val: any, resolveUp: boolean = false): void {
     // Allow variables with dots by automatically creating the nested structure
     let frame: this | Frame | null = this;
-    const obj = this.variables;
 
     if (resolveUp) {
       frame = this.resolve(name.split('.')[0], true);
@@ -17,12 +16,14 @@ export default class Frame {
         return;
       }
     }
-    set(obj, name, val);
+    set(this.variables, name, val);
   }
 
   public get(name: string): any | null {
     const val = this.variables[name];
-    return val === undefined ? null : val;
+    return val === undefined
+      ? null
+      : val;
   }
 
   public resolve(name: string, forWrite?: boolean): null | Frame {
@@ -41,8 +42,11 @@ export default class Frame {
       if (val !== undefined) {
         return val;
       }
-      return p && p.lookup(name);
+      if (p) {
+        return p.lookup(name);
+      }
     }
+    return;
   }
 
   public constructor(

--- a/packages/superjucks/src/Parser.ts
+++ b/packages/superjucks/src/Parser.ts
@@ -130,14 +130,19 @@ export default class Parser {
           );
         }
       }
+
       if (node instanceof Nodes.Dict) {
         // TODO: check for errors
-        const key = this.parsePrimary();
+        let key = this.parsePrimary();
         // we expect a key/value pair for dicts, separated by a colon
         if (!this.skip(Token.COLON)) {
+          // we're working with a shorthand dictionary entry
           node.addChild(key);
         } else {
-          // TODO: check for errors
+          // longhand dictionary entry, valid keys must be literals or variable interpolations
+          if (!(key instanceof Nodes.Array)) {
+            key = new Nodes.Literal(key.line, key.col, { value: key.value });
+          }
           const value = this.parseExpression();
           node.addChild(new Nodes.Pair(key.line, key.col, { key, value }));
         }

--- a/packages/superjucks/src/nodes/Dict.ts
+++ b/packages/superjucks/src/nodes/Dict.ts
@@ -9,13 +9,14 @@ export default class DictNode extends Aggregate {
     compiler.emit('{ ', false);
     for (const child of this.children) {
       if (child instanceof Nodes.Symbol) {
-        // if we're using symbols as keys, make sure they're in frame.
-        if (!frame.get(child.value)) {
+        // if we're using symbols as shorthand keys, make sure they're in frame.
+        if (frame.get(child.value) === null) {
           throw new Error(
-            `Cannot compile "${child.value}" into shorthand dictionary without corresponding frame variable.`
+            `Cannot compile "${child.value}" into shorthand dictionary item without corresponding frame variable.`
           );
         }
       }
+      frame.set(child.value, true);
       compiler.compile(child, frame);
       if (this.children.indexOf(child) < this.children.length - 1) {
         compiler.emit(', ', false);

--- a/packages/superjucks/src/nodes/Is.ts
+++ b/packages/superjucks/src/nodes/Is.ts
@@ -25,7 +25,7 @@ export default class IsNode extends Node {
     if (this.right instanceof Nodes.FunctionCall) {
       right = this.right.name.value;
     }
-    compiler.emit(`(await lib.test('${ right }', `, false);
+    compiler.emit(`await lib.test('${ right }', `, false);
     compiler.compile(this.left, frame);
     if (this.right.args) {
       for (const child of this.right.args.children) {
@@ -33,6 +33,6 @@ export default class IsNode extends Node {
         child.compile(compiler, frame);
       }
     }
-    compiler.emit(')) === true', false);
+    compiler.emit(') === true', false);
   }
 }

--- a/packages/superjucks/src/nodes/Pair.ts
+++ b/packages/superjucks/src/nodes/Pair.ts
@@ -6,7 +6,8 @@ export default class PairNode extends Node {
   public key: Node;
   public value: Node;
   public compile(compiler: Compiler, frame: Frame) {
-    compiler.emit(`${ this.key.value }: `, false);
+    compiler.compile(this.key, frame);
+    compiler.emit(': ', false);
     compiler.compile(this.value, frame);
   }
 }

--- a/packages/superjucks/src/nodes/Set.ts
+++ b/packages/superjucks/src/nodes/Set.ts
@@ -1,9 +1,14 @@
+import Compiler from '../Compiler';
+import Frame from '../Frame';
 import { Token } from '../Lexer';
 import Node from '../Node';
 import Parser from '../Parser';
 
+import AggregateNode from './Aggregate';
 import ArrayNode from './Array';
 import CaptureNode from './Capture';
+import PairNode from './Pair';
+import SymbolNode from './Symbol';
 
 export default class SetNode extends Node {
 
@@ -13,17 +18,12 @@ export default class SetNode extends Node {
     const tag = parser.peekToken();
     parser.skipValue(Token.SYMBOL, tagStart);
 
-    const targets = new ArrayNode(tag.line, tag.col, { children: [] });
-    const node = new SetNode(tag.line, tag.col, { targets, value: null });
-
-    let target = parser.parsePrimary();
-    while (target) {
-      node.targets.children.push(target);
-      if (!parser.skip(Token.COMMA)) {
-        break;
-      }
-      target = parser.parsePrimary();
+    const target = parser.parsePrimary();
+    if (parser.skip(Token.COMMA)) {
+      throw new Error('No commas! Use object or array destructuring instead.');
     }
+
+    const node = new SetNode(tag.line, tag.col, { target, value: null });
 
     if (parser.skipValue(Token.OPERATOR, '=')) {
       node.value = parser.parseExpression();
@@ -31,13 +31,33 @@ export default class SetNode extends Node {
     } else if (parser.skip(Token.BLOCK_END)) {
       node.fields.push('body');
       node.value = null;
-      node.body = new CaptureNode(tag.line, tag.col, { body: parser.parseUntilBlocks(tagEnd + tagStart) });
+      node.body = new CaptureNode(tag.line, tag.col, {
+        body: parser.parseUntilBlocks(tagEnd + tagStart)
+      });
       parser.advanceAfterBlockEnd();
     }
     return node;
   }
 
-  public compile() {
-    return;
+  public compile(compiler: Compiler, frame: Frame) {
+    const f = new Frame(frame);
+    const id = compiler.id();
+    const symbols = this.findAll(SymbolNode);
+    for (const sym of symbols) {
+      f.set(sym.value, true);
+    }
+    compiler.emitLine('{');
+    compiler.indent(() => {
+      compiler.emit('let ');
+      compiler.compile(this.target, f);
+      compiler.emit(' = ', false);
+      compiler.compile(this.value, f);
+      compiler.emit(';', false);
+      compiler.emitLine('');
+      for (const sym of symbols) {
+        compiler.emitLine(`lib.frame.set('${ sym.value }', ${ sym.value });`);
+      }
+    });
+    compiler.emitLine('}');
   }
 }

--- a/packages/superjucks/src/tests/Parser.ts
+++ b/packages/superjucks/src/tests/Parser.ts
@@ -55,21 +55,42 @@ test('should parse aggregate types', t => {
       [Nodes.List, [Nodes.Literal, 1], [Nodes.Literal, 2], [Nodes.Literal, 3]]
     ]
   ]);
-  t.deepEqual(p(`{{ { hoo, boy } }}`), [
-    Nodes.Root,
-    [Nodes.Output, [Nodes.Dict, [Nodes.Symbol, 'hoo'], [Nodes.Symbol, 'boy']]]
-  ]);
-
-  // this should probably be 'literal', 'literal' unless it has the square
-  // brackets
-  t.deepEqual(p('{{ { foo: 1, "two": 2 } }}'), [
+  t.deepEqual(p(`{{ { hoo: { bar: 2 }, boy } }}`), [
     Nodes.Root,
     [
       Nodes.Output,
       [
         Nodes.Dict,
-        [Nodes.Pair, [Nodes.Symbol, 'foo'], [Nodes.Literal, 1]],
-        [Nodes.Pair, [Nodes.Literal, 'two'], [Nodes.Literal, 2]]
+        [
+          Nodes.Pair,
+          [Nodes.Literal, 'hoo'],
+          [
+            Nodes.Dict,
+            [Nodes.Pair, [Nodes.Literal, 'bar'], [Nodes.Literal, 2]]
+          ]
+        ],
+        [Nodes.Symbol, 'boy']
+      ]
+    ]
+  ]);
+
+  // this should probably be 'literal', 'literal' unless it has the square
+  // brackets
+  t.deepEqual(p('{{ { foo: 1, ["two" + 2]: 2 } }}'), [
+    Nodes.Root,
+    [
+      Nodes.Output,
+      [
+        Nodes.Dict,
+        [Nodes.Pair, [Nodes.Literal, 'foo'], [Nodes.Literal, 1]],
+        [
+          Nodes.Pair,
+          [
+            Nodes.Array,
+            [Nodes.Add, [Nodes.Literal, 'two'], [Nodes.Literal, 2]]
+          ],
+          [Nodes.Literal, 2]
+        ]
       ]
     ]
   ]);

--- a/packages/superjucks/src/tests/helpers/compile.ts
+++ b/packages/superjucks/src/tests/helpers/compile.ts
@@ -2,12 +2,11 @@ import Compiler from '../../Compiler';
 import Frame from '../../Frame';
 import { parse } from '../../Parser';
 
-export default async function compile(ast?: any, frame = new Frame()): Promise<string> {
-  const compiler = new Compiler();
-  try {
-  await compiler.compile(ast, frame);
-  } catch (e) {
-    throw e;
-  }
-  return compiler.buffer.join('');
+export default function compile(ast?: any, frame = new Frame()): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const compiler = new Compiler();
+    compiler.compile(ast, frame)
+      .then(() => resolve(compiler.buffer.join('')))
+      .catch(reject);
+  });
 }

--- a/packages/superjucks/src/tests/helpers/run.ts
+++ b/packages/superjucks/src/tests/helpers/run.ts
@@ -1,11 +1,17 @@
 import runtime from 'superjucks-runtime';
 import Superjucks from '../../configs/Superjucks/Config';
+import Frame from '../../Frame';
 import compile from './compile';
 import { ast } from './parse';
 
 export default async function run(input: string, ctx?: any) {
   const parsed = ast(input);
   const str = await compile(parsed);
-  const fn = new Function(str)();
-  return fn(runtime(ctx, new Superjucks()));
+  try {
+    const fn = new Function(str)();
+    const lib = runtime(ctx, new Superjucks(), new Frame());
+    return fn(lib);
+  } catch (e) {
+    console.info(str);
+  }
 }

--- a/packages/superjucks/src/tests/nodes/Dict.ts
+++ b/packages/superjucks/src/tests/nodes/Dict.ts
@@ -2,6 +2,7 @@ import test from 'ava';
 import Frame from '../../Frame';
 import * as Nodes from '../../nodes/index';
 import compile from '../helpers/compile';
+import { parse as p } from '../helpers/parse';
 
 test('should compile a shorthand object node', async t => {
   const frame = new Frame();
@@ -16,27 +17,24 @@ test('should compile a shorthand object node', async t => {
   t.is(await compile(ast, frame), '{ one, foobar }');
 });
 
-test('should refuse to compile a shorthand object node with symbols not in scope', async t => {
+test('should throw when attempting to shorthand a key with a symbol not in scope', async t => {
   const ast = new Nodes.Dict(0, 0, {
     children: [
       new Nodes.Symbol(0, 0, { value: 'one' }),
       new Nodes.Symbol(0, 0, { value: 'foobar' })
     ]
   });
-  await t.throws(
-    compile(ast),
-    'Cannot compile "one" into shorthand dictionary without corresponding frame variable.'
-  );
+  await t.throws(compile(ast));
 });
 
 test('should compile a longhand object node', async t => {
   const ast = new Nodes.Dict(0, 0, {
     children: [
       new Nodes.Pair(0, 0, {
-        key: new Nodes.Symbol(0, 0, { value: 'foo' }),
+        key: new Nodes.Literal(0, 0, { value: 'foo' }),
         value: new Nodes.Literal(0, 0, { value: 42 })
       })
     ]
   });
-  t.is(await compile(ast), '{ foo: 42 }');
+  t.is(await compile(ast), '{ \'foo\': 42 }');
 });

--- a/packages/superjucks/src/tests/nodes/Is.ts
+++ b/packages/superjucks/src/tests/nodes/Is.ts
@@ -54,7 +54,7 @@ test('should compile an is-not node', async t => {
   });
   t.is(
     await compile(ast),
-    "!((await lib.test('callable', lib.lookup('foo'))) === true)"
+    "!(await lib.test('callable', lib.lookup('foo')) === true)"
   );
 });
 
@@ -70,7 +70,7 @@ test('should compile an is-not node', async t => {
   });
   t.is(
     await compile(ast),
-    "(await lib.test('greaterThan', lib.lookup('foo'), 5)) === true"
+    "await lib.test('greaterThan', lib.lookup('foo'), 5) === true"
   );
 });
 

--- a/packages/superjucks/src/tests/nodes/Pair.ts
+++ b/packages/superjucks/src/tests/nodes/Pair.ts
@@ -3,8 +3,8 @@ import * as Nodes from '../../nodes/index';
 import compile from '../helpers/compile';
 
 test('should compile pair node', async t => {
-  const key = new Nodes.Symbol(0, 0, { value: 'bar' });
+  const key = new Nodes.Literal(0, 0, { value: 'bar' });
   const value = new Nodes.Literal(0, 0, { value: 42 });
   const ast = new Nodes.Pair(0, 0, { key, value });
-  t.is(await compile(ast), 'bar: 42');
+  t.is(await compile(ast), '\'bar\': 42');
 });

--- a/packages/superjucks/src/tests/nodes/for.ts
+++ b/packages/superjucks/src/tests/nodes/for.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import * as Nodes from '../../nodes/index';
 import { parse as p } from '../helpers/parse';
+import run from '../helpers/run';
 
 test('should parse for blocks', t => {
   t.deepEqual(p('{% for x of [1, 2] %}{{ x }}{% endfor %}'), [
@@ -100,4 +101,13 @@ test('should attempt to unpack key-valued objects', t => {
 
 test('should throw on old keyword', t => {
   t.throws(() => p('{% for { x, y } in [] %}{{ x }}{{ y }}{% endfor %}'));
+});
+
+test('should compile into lib fn call', async t => {
+  t.is(
+    await run(
+      `{%- for a of iterable -%}{{ a }}: (happy!)\n{% else -%}(sad!){%- endfor -%}`,
+      { iterable: '12'}
+    ),
+  '1: (happy!)\n2: (happy!)\n');
 });

--- a/packages/superjucks/src/tests/nodes/set.ts
+++ b/packages/superjucks/src/tests/nodes/set.ts
@@ -1,26 +1,23 @@
 import test from 'ava';
 import * as Nodes from '../../nodes/index';
 import { parse as p } from '../helpers/parse';
+import run from '../helpers/run';
+
+test('should throw for python-style destructuring', async t => {
+  await t.throws(() => p('{% set foo, bar = baz %}'));
+});
 
 test('should parse set blocks', t => {
-  t.deepEqual(p(`{% set foo, baz = bar %}`), [
-    Nodes.Root,
-    [
-      Nodes.Set,
-      [Nodes.Array, [Nodes.Symbol, 'foo'], [Nodes.Symbol, 'baz']],
-      [Nodes.Symbol, 'bar']
-    ]
-  ]);
   t.deepEqual(p(`{% set foo = bar %}`), [
     Nodes.Root,
-    [Nodes.Set, [Nodes.Array, [Nodes.Symbol, 'foo']], [Nodes.Symbol, 'bar']]
+    [Nodes.Set, [Nodes.Symbol, 'foo'], [Nodes.Symbol, 'bar']]
   ]);
 
   t.deepEqual(p(`{% set foo %}bar{% endset %}`), [
     Nodes.Root,
     [
       Nodes.Set,
-      [Nodes.Array, [Nodes.Symbol, 'foo']],
+      [Nodes.Symbol, 'foo'],
       null,
       [Nodes.Capture, [Nodes.Aggregate, [Nodes.Output, [Nodes.Literal, 'bar']]]]
     ]
@@ -32,7 +29,7 @@ test('should parse destructured set blocks', t => {
     Nodes.Root,
     [
       Nodes.Set,
-      [Nodes.Array, [Nodes.Dict, [Nodes.Symbol, 'foo']]],
+      [Nodes.Dict, [Nodes.Symbol, 'foo']],
       [Nodes.Symbol, 'bar']
     ]
   ]);
@@ -41,8 +38,13 @@ test('should parse destructured set blocks', t => {
     Nodes.Root,
     [
       Nodes.Set,
-      [Nodes.Array, [Nodes.Array, [Nodes.Symbol, 'foo']]],
+      [Nodes.Array, [Nodes.Symbol, 'foo']],
       [Nodes.Symbol, 'bar']
     ]
   ]);
+});
+
+test('should compile variable sets', async t => {
+  const res = await run('{% set foo = \'bar\' %}{{ foo }}');
+  t.is(res, 'bar');
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2017",
     "module": "commonjs",
     "rootDir": "src",
     "outDir": "lib",


### PR DESCRIPTION
  - dictionary keys are now parsed as literals instead of symbols.
    - of course, shorthand keys are still symbols
  - better support for destructuring
  - compilation support for For and Set nodes.
  - jiggers around tooling to get watching working